### PR TITLE
style: add font family and image asset

### DIFF
--- a/client/public/assets/svgs/background-lines.svg
+++ b/client/public/assets/svgs/background-lines.svg
@@ -1,0 +1,36 @@
+<svg width="1440" height="900" viewBox="0 0 1440 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_2189_1243)">
+<rect width="1576" height="1576" transform="translate(-68 -338)" fill=""/>
+<path d="M1507.76 -338.11L966.576 202.841V697.037L1507.76 1237.35" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1507.44 -75.1922L1090.12 202.842L1090.13 697.028L1507.42 975.748" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M324.646 -338.11L595.948 202.841L595.941 697.022L325.664 1237.35" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1507.44 56.0688L1213.67 202.842L1213.67 697.03L1507.42 844.162" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M-68.0186 -74.5659L348.855 202.842L348.848 697.028L-68.0332 975.145" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M-68.043 56.4213L225.281 202.843V697.036L-68.0356 843.816" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M-68.0488 135.033L101.732 202.842V697.035L-68.0342 765.006" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1113.36 -338.11L843.035 202.841V697.037L1112.37 1237.35" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1507.44 134.804L1337.21 202.843L1337.22 697.029L1507.42 765.226" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M719.003 -338.11L719.491 202.841V690.298L719.018 1237.35" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M-67.6895 -338.11L472.398 202.841L472.391 697.029L-67.6895 1237.35" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1507.76 159.102H-67.6895" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1507.76 130.847H-67.6895" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1507.76 53.8839H-67.6895" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1507.76 96.5131H-67.6895" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1507.76 182.753H-67.6895" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1507.42 846.392H-68.0352" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1507.42 803.648H-68.0352" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1507.42 769.224H-68.0352" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1507.42 740.897H-68.0352" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1507.42 717.179H-68.0352" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1507.42 697.036H-68.0352" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M-67.3242 202.842H1508.06" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M-67.3242 326.384H1508.06" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M-67.3242 449.928H1508.06" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M-67.3242 573.47H1508.06" stroke="white" stroke-opacity="0.36" stroke-width="0.609907" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_2189_1243">
+<rect width="1576" height="1576" fill="white" transform="translate(-68 -338)"/>
+</clipPath>
+</defs>
+</svg>

--- a/client/src/components/sections/Hero.tsx
+++ b/client/src/components/sections/Hero.tsx
@@ -3,17 +3,22 @@ import { PoolSelector } from "@/components/PoolSelector";
 
 export function Hero() {
   return (
-    <section className="relative min-h-screen flex items-center justify-center overflow-hidden py-32 bg-background">
-      <div className="container relative mx-auto px-4">
-        <div className="max-w-4xl mx-auto">
-          <motion.h1 
-            className="text-6xl md:text-7xl font-mono mb-8 tracking-tight"
+    <section className='relative min-h-screen flex items-center justify-center overflow-hidden py-32 bg-background'>
+      <div className='absolute top-0 left-0 right-0 bottom-0'>
+        <div className='relative h-full w-full'>
+          <img src='/assets/svgs/background-lines.svg' alt='background lines' className=' object-cover w-full h-full' />
+        </div>
+      </div>
+      <div className='container relative mx-auto px-4'>
+        <div className='max-w- mx-auto'>
+          <motion.h1
+            className='text-6xl md:text-[6.75rem] leading-[7.5rem] font-dm-mono mb-8 tracking-tight'
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6 }}
           >
             One giant leap
-            <br /> 
+            <br />
             for bitcoin mining
           </motion.h1>
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,3 +1,5 @@
+@import url("https://fonts.googleapis.com/css2?family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&display=swap");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -16,9 +18,10 @@
   }
 
   body {
-    @apply font-sans antialiased bg-black text-foreground min-h-screen;
+    @apply antialiased bg-black text-foreground min-h-screen;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    font-family: "DM Mono", monospace;
   }
 
   /* Improved Typography Scale */

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -84,6 +84,9 @@ export default {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
       },
+      fontFamily: {
+        "dm-mono": ['"DM Mono"', "monospace"],
+      },
     },
   },
   plugins: [require("tailwindcss-animate"), require("@tailwindcss/typography")],


### PR DESCRIPTION
This pr updates the font family of the landing page #16  and adds the background lines to the hero section #3 

@pavlenex @Jeezman 

<img width="1724" alt="Screenshot 2025-03-20 at 14 20 20" src="https://github.com/user-attachments/assets/83c52a6f-3996-4ac2-ba59-0b7dbe3c40cd" />
