### PR TITLE
chore: Navbar links overlay 

### DIFF
--- a/app/src/components/Navigation.tsx
+++ b/app/src/components/Navigation.tsx
@@ -56,8 +56,7 @@ export function Navigation() {
           </NavLink>
 
           {/* Desktop Navigation - Centered */}
-          <div className='hidden lg:block absolute left-1/2 -translate-x-1/2'>
-            {/* <div className='hidden md:block absolute left-1/2 -translate-x-1/2'> */}
+          <div className='hidden lg:block xl:absolute xl:left-1/2 xl:-translate-x-1/2'>
             <div className='bg-[#2F2F2F] backdrop-blur-sm'>
               <NavigationMenu className='h-10'>
                 <NavigationMenuList className='space-x-0 p-1'>


### PR DESCRIPTION
This pr fixes the navbar links section overlay on the translator icon from the inclusion of blog link in screen sizes of 1024px.

![Screenshot 2025-05-19 at 07 03 58](https://github.com/user-attachments/assets/375df65a-283d-4423-b4fc-e352e77e574e)
