### PR TITLE
update script to run chron job

### DIFF
--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -3,6 +3,11 @@ on:
   repository_dispatch:
     types:
       - update-submodule
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 4 * * *" # every day at 4am
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This change updates the `uppdate-submodule` script to include a chron job to check for changes daily.

@pavlenex we will need to include a github personal access token in the repository's secrets. This is to grant necessary permissions to make necessary for the submodules